### PR TITLE
[MMC-1891] Updates to build and readme for jitpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,23 @@ Create and update your Mailchimp contacts from your Android app. The Mailchimp S
 
 Coming Soon
 
+### Adding The Mailchimp SDK to your Project
+
+First, add https://jitpack.io to your list of maven repositories if it's not already present. Ex. This is an list of Gradle repositories that contains jitpack
+
+```gradle
+repositories {
+    mavenCentral()
+    maven { url 'https://jitpack.io' } // <-- New repository
+}
+```
+
+Next add the Mailchimp SDK to your list of dependencies. Below is a gradle example
+
+```gradle
+implementation 'com.github.mailchimp:Mailchimp-SDK-Android:0.1.0'
+```
+
 ### Initializing the SDK
 
 The first step is to create the configuration object. The configuration object has three different fields.

--- a/mailchimp-sdk-api/build.gradle
+++ b/mailchimp-sdk-api/build.gradle
@@ -9,8 +9,36 @@
  * limitations under the License.
  */
 
-apply plugin: 'java-library'
-apply plugin: 'kotlin'
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
+
+android {
+    compileSdkVersion 28
+
+
+    defaultConfig {
+        minSdkVersion 21
+        targetSdkVersion 28
+        versionCode 1
+        versionName "1.0"
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
+
+}
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
@@ -23,20 +51,16 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.23.0'
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0"
 }
-
-sourceCompatibility = "7"
-targetCompatibility = "7"
-
 repositories {
     mavenCentral()
 }
-compileKotlin {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}
-compileTestKotlin {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}
+//compileKotlin {
+//    kotlinOptions {
+//        jvmTarget = "1.8"
+//    }
+//}
+//compileTestKotlin {
+//    kotlinOptions {
+//        jvmTarget = "1.8"
+//    }
+//}

--- a/mailchimp-sdk-api/build.gradle
+++ b/mailchimp-sdk-api/build.gradle
@@ -51,16 +51,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.23.0'
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0"
 }
+
 repositories {
     mavenCentral()
 }
-//compileKotlin {
-//    kotlinOptions {
-//        jvmTarget = "1.8"
-//    }
-//}
-//compileTestKotlin {
-//    kotlinOptions {
-//        jvmTarget = "1.8"
-//    }
-//}

--- a/mailchimp-sdk-api/src/main/AndroidManifest.xml
+++ b/mailchimp-sdk-api/src/main/AndroidManifest.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Licensed under the Mailchimp Mobile SDK License Agreement (the "License");
+  ~ you may not use this file except in compliance with the License. Unless
+  ~ required by applicable law or agreed to in writing, software distributed
+  ~ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+  ~ OR CONDITIONS OF ANY KIND, either or express or implied.
+  ~
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--
+  ~ Licensed under the Mailchimp Mobile SDK License Agreement (the "License");
+  ~ you may not use this file except in compliance with the License. Unless
+  ~ required by applicable law or agreed to in writing, software distributed
+  ~ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+  ~ OR CONDITIONS OF ANY KIND, either or express or implied.
+  ~
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.mailchimp.sdk.api"/>


### PR DESCRIPTION
To make our repo compliant with Jitpack I turned the api module from a java module to an android module. I also updated the README with instructions for adding the SDK to your project.

*Testing*
1. Test to see whether or not you can follow the instructions to add the sdk as a dependency to a project.

*Note*
I haven't created the 0.1.0 tag yet so when adding the dependency replace that with 'master-SNAPSHOT' for testing